### PR TITLE
drop URLs from home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,10 +34,6 @@ title: Modular provisioning platform
           <strong>
             How to Build an OpenStack Cloud
           </strong>
-          <br>
-          <small>
-            http://blog.adamspiers.org/2014/12/11/susecon-usb-stick-howto/
-          </small>
         </a>
       </p>
 
@@ -46,10 +42,6 @@ title: Modular provisioning platform
           <strong>
             Google Group List
           </strong>
-          <br>
-          <small>
-            https://groups.google.com/forum/#!forum/crowbar
-          </small>
         </a>
       </p>
 
@@ -58,10 +50,6 @@ title: Modular provisioning platform
           <strong>
             Gitter Chat
           </strong>
-          <br>
-          <small>
-            https://gitter.im/crowbar/crowbar
-          </small>
         </a>
       </p>
 
@@ -70,10 +58,6 @@ title: Modular provisioning platform
           <strong>
             IRC Webchat
           </strong>
-          <br>
-          <small>
-            http://webchat.freenode.net/?channels=%23crowbar
-          </small>
         </a>
       </p>
 
@@ -82,10 +66,6 @@ title: Modular provisioning platform
           <strong>
             OpenHub Statistics
           </strong>
-          <br>
-          <small>
-            https://www.openhub.net/p/crowbar
-          </small>
         </a>
       </p>
 
@@ -94,10 +74,6 @@ title: Modular provisioning platform
           <strong>
             Source Code on GitHub
           </strong>
-          <br>
-          <small>
-            https://github.com/crowbar
-          </small>
         </a>
       </p>
 
@@ -106,10 +82,6 @@ title: Modular provisioning platform
           <strong>
             SUSE OpenStack Cloud
           </strong>
-          <br>
-          <small>
-            https://www.suse.com/products/suse-cloud/
-          </small>
         </a>
       </p>
     </div>


### PR DESCRIPTION
They needlessly clutter the page.  No other software project with a decent website does this.
